### PR TITLE
Add flag to keep cache files untouched

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -156,7 +156,7 @@ func (r *Repo) unlink(h errs.Handler, pkgfiles []string) error {
 //
 // TODO: What happens when there are multiple files, and you delete
 // the most recent one. Which file is deleted?
-func (r *Repo) Update(h errs.Handler, pkgnames ...string) error {
+func (r *Repo) Update(h errs.Handler, keepCacheFiles bool, pkgnames ...string) error {
 	errs.Init(&h)
 
 	pkgs, err := r.ReadMeta(h, pkgnames...)
@@ -175,7 +175,7 @@ func (r *Repo) Update(h errs.Handler, pkgnames ...string) error {
 		if p.HasUpdate() || len(pkgnames) > 0 {
 			updates = append(updates, p.Pkg().Filename)
 		}
-		if p.HasObsolete() {
+		if !keepCacheFiles && p.HasObsolete() {
 			obsolete = append(obsolete, pu.Map(p.Obsolete(), pu.PkgFilename)...)
 		}
 	}
@@ -195,7 +195,7 @@ func (r *Repo) Update(h errs.Handler, pkgnames ...string) error {
 
 // Reset deletes the repository database and readd all the packages.
 // This is the same as unlinking the database and then running Update.
-func (r *Repo) Reset(h errs.Handler) error {
+func (r *Repo) Reset(h errs.Handler, keepCacheFiles bool) error {
 	errs.Init(&h)
 
 	err := r.DeleteDatabase()
@@ -203,7 +203,7 @@ func (r *Repo) Reset(h errs.Handler) error {
 		return err
 	}
 
-	return r.Update(h)
+	return r.Update(h, keepCacheFiles)
 }
 
 // DeleteDatabase deletes the repository database (but not the files).

--- a/cmd/repoctl/reset.go
+++ b/cmd/repoctl/reset.go
@@ -8,6 +8,8 @@ import "github.com/spf13/cobra"
 
 func init() {
 	MainCmd.AddCommand(resetCmd)
+
+	resetCmd.Flags().BoolVarP(&keepCacheFiles, "keep-cache", "k", false, "keep cache files untouched")
 }
 
 var resetCmd = &cobra.Command{
@@ -19,6 +21,6 @@ var resetCmd = &cobra.Command{
   recreates it by running the update command.
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return Repo.Reset(nil)
+		return Repo.Reset(nil, keepCacheFiles)
 	},
 }

--- a/cmd/repoctl/status.go
+++ b/cmd/repoctl/status.go
@@ -12,13 +12,15 @@ import (
 )
 
 var (
-	statusAUR     bool
-	statusMissing bool
+	keepCacheFiles bool
+	statusAUR      bool
+	statusMissing  bool
 )
 
 func init() {
 	MainCmd.AddCommand(statusCmd)
 
+	statusCmd.Flags().BoolVarP(&keepCacheFiles, "keep-cache", "k", false, "keep cache files untouched")
 	statusCmd.Flags().BoolVarP(&statusAUR, "aur", "a", false, "check AUR for upgrades")
 	statusCmd.Flags().BoolVarP(&statusMissing, "missing", "m", false, "highlight packages missing in AUR")
 }
@@ -31,7 +33,7 @@ var statusCmd = &cobra.Command{
   In particular, the following is shown:
 
     "updated":  database entries that can be updated/added (new package files)
-    "obsolete": package files that can be deleted (or backed up)
+    "obsolete": package files that can be deleted (or backed up) (only without -k)
     "removal":  database entries that should be deleted (no package files)
     "upgrade":  packages with updates in AUR (only with -a)
     "!aur":     packages unavailable in AUR (only with -m)
@@ -70,7 +72,7 @@ var statusCmd = &cobra.Command{
 			if !p.HasFiles() {
 				flags = append(flags, col.Sprint("@rremoval"))
 			}
-			if o := p.Obsolete(); len(o) > 0 {
+			if o := p.Obsolete(); !keepCacheFiles && len(o) > 0 {
 				flags = append(flags, col.Sprintf("@yobsolete(@|%d@y)", len(o)))
 			}
 			if statusMissing && p.AUR == nil && !ignore[p.Name] {

--- a/cmd/repoctl/update.go
+++ b/cmd/repoctl/update.go
@@ -8,6 +8,8 @@ import "github.com/spf13/cobra"
 
 func init() {
 	MainCmd.AddCommand(updateCmd)
+
+	updateCmd.Flags().BoolVarP(&keepCacheFiles, "keep-cache", "k", false, "keep cache files untouched")
 }
 
 var updateCmd = &cobra.Command{
@@ -24,6 +26,6 @@ var updateCmd = &cobra.Command{
 `,
 	Example: `  repoctl update fairsplit`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return Repo.Update(nil, args...)
+		return Repo.Update(nil, keepCacheFiles, args...)
 	},
 }


### PR DESCRIPTION
I quickly prototyped #30 to see how it will look like, I must say I kinda like it. The change is rather small, and the output of `repoctl` is much cleaner and "actionable" now. 

Now `repoctl status -k` doesn't bloat the output with false `obsolete` records and I only see clean actionable suggestions (remove & update), and `repoctl update -k` also silently ignores the cache files and doesn't print anything to output.