### PR TITLE
Zstd database format

### DIFF
--- a/conf/config.go
+++ b/conf/config.go
@@ -202,7 +202,7 @@ func (c *Configuration) Init() error {
 
 	// Perform a check on database extension.
 	var extOk bool
-	for _, ext := range []string{".db.tar", ".db.tar.gz", ".db.tar.xz", ".db.tar.bz2"} {
+	for _, ext := range []string{".db.tar", ".db.tar.gz", ".db.tar.xz", ".db.tar.bz2", ".db.tar.zst"} {
 		if strings.HasSuffix(c.database, ext) {
 			extOk = true
 			break
@@ -210,7 +210,7 @@ func (c *Configuration) Init() error {
 	}
 	if !extOk {
 		fmt.Fprintf(os.Stderr, "Warning: specified repository database %q has an unexpected extension.\n", c.database)
-		fmt.Fprintf(os.Stderr, "Should be one of \".db.tar\", \".db.tar.gz\", \".db.tar.xz\", or \"db.tar.bz2\".\n")
+		fmt.Fprintf(os.Stderr, "Should be one of \".db.tar\", \".db.tar.gz\", \".db.tar.xz\", \"db.tar.bz2\", or \"db.tar.zst\".\n")
 	}
 
 	return nil


### PR DESCRIPTION
Hi,

As with issue #47 the database itself can also be archived with Zstd.

I have been managing a db.tar.zst database without issue with this change.