### PR TITLE
Remove outdated references to --backup flag in help

### DIFF
--- a/add.go
+++ b/add.go
@@ -42,7 +42,6 @@ var addCmd = &cobra.Command{
 
   If the backup directory resolves to the repository directory,
   then obsolete package files are ignored.
-  You can specify --backup=false to force them to be deleted.
 `,
 	Example:           `  repoctl add -m ./fairsplit-1.0.pkg.tar.gz`,
 	ValidArgsFunction: completeLocalPackageFiles,

--- a/remove.go
+++ b/remove.go
@@ -26,11 +26,10 @@ var removeCmd = &cobra.Command{
 
   If the backup directory resolves to the repository directory,
   then package files are ignored; repoctl update will add them again.
-  In this case, you probably want to use --backup=false to force
+  In this case, you probably want to use a profile with backup=false to force
   them to be deleted.
 `,
-	Example: `  repoctl rm fairsplit
-  repoctl rm --backup=false fairsplit`,
+	Example:           `  repoctl rm fairsplit`,
 	ValidArgsFunction: completeRepoPackageNames,
 	PreRunE:           ProfileInit,
 	PostRunE:          ProfileTeardown,

--- a/update.go
+++ b/update.go
@@ -32,8 +32,7 @@ var updateCmd = &cobra.Command{
   If the backup directory resolves to the repository directory,
   then obsolete package files are ignored.
 `,
-	Example: `  repoctl update fairsplit
-  repoctl update --backup=false`,
+	Example:           `  repoctl update fairsplit`,
 	ValidArgsFunction: completeRepoPackageNames,
 	PreRunE:           ProfileInit,
 	PostRunE:          ProfileTeardown,


### PR DESCRIPTION
Hi,

As discuted here https://github.com/cassava/repoctl/issues/63:
I remove the few lines related to `--backup` param.

Close: #63 