### PR TITLE
Do not hardcode paths

### DIFF
--- a/pacman/alpm/testdata/prepare.go
+++ b/pacman/alpm/testdata/prepare.go
@@ -50,7 +50,7 @@ func generateData(vs []string, filename string) {
 	buf := bufio.NewWriter(file)
 	for _, a := range vs {
 		for _, b := range vs {
-			cmd := exec.Command("/usr/bin/vercmp", a, b)
+			cmd := exec.Command("vercmp", a, b)
 			bs, err := cmd.Output()
 			if err != nil {
 				log.Println(err)

--- a/repo/database.go
+++ b/repo/database.go
@@ -16,8 +16,8 @@ import (
 )
 
 var (
-	SystemRepoAdd    = "/usr/bin/repo-add"
-	SystemRepoRemove = "/usr/bin/repo-remove"
+	SystemRepoAdd    = "repo-add"
+	SystemRepoRemove = "repo-remove"
 )
 
 // DeleteDatabase deletes the repository database (but not the files).


### PR DESCRIPTION
Do not hardcode binary paths such as repo-add and repo-remove. This is important when building this package on a non FHS system. (Specifically, this was tested on NixOS)