### PR TITLE
Fix data-eating behavior of `Repo.ReadNames()` and friends

### DIFF
--- a/down.go
+++ b/down.go
@@ -111,7 +111,7 @@ var downCmd = &cobra.Command{
 		// First, populate the initial list of packages to download.
 		var list []string
 		if downAll {
-			names, err := Repo.ReadNames(nil)
+			names, err := Repo.ReadAllNames(nil)
 			if err != nil {
 				return err
 			}

--- a/repo/actions.go
+++ b/repo/actions.go
@@ -90,6 +90,9 @@ func (r *Repo) add(h errs.Handler, pkgfiles []string, ar func(string, string) er
 	}
 
 	pkgs, err := r.FindSimilar(h, added...)
+	if err != nil {
+		return err
+	}
 	return r.Dispatch(h, pu.Map(pkgs, pu.PkgFilename)...)
 }
 

--- a/repo/find.go
+++ b/repo/find.go
@@ -102,7 +102,7 @@ func (r *Repo) FindNewest(h errs.Handler, pkgnames ...string) (pacman.Packages, 
 	var pkgs pacman.Packages
 	var err error
 	if len(pkgnames) == 0 {
-		pkgs, err = r.ReadDir(h)
+		pkgs, err = r.ReadAllNames(h)
 	} else {
 		pkgs, err = r.ReadNames(h, pkgnames...)
 	}

--- a/repo/read.go
+++ b/repo/read.go
@@ -39,16 +39,18 @@ func (r *Repo) ReadDir(h errs.Handler) (pacman.Packages, error) {
 }
 
 // ReadNames returns all packages in the repository that match the given
-// names. If no names are given, all packages found are returned.
+// names. If no names are given, no packages are returned.
 func (r *Repo) ReadNames(h errs.Handler, pkgnames ...string) (pacman.Packages, error) {
 	errs.Init(&h)
-	if len(pkgnames) == 0 {
-		return r.ReadDir(h)
-	}
-
 	pkgs, err := pacman.ReadNames(h, r.Directory, pkgnames...)
 	r.MakeAbs(pkgs)
 	return pkgs, err
+}
+
+// ReadAllNames returns all packages in the repository.
+func (r *Repo) ReadAllNames(h errs.Handler) (pacman.Packages, error) {
+	errs.Init(&h)
+	return r.ReadDir(h)
 }
 
 // ReadMeta returns all meta packages in the repository that match the given


### PR DESCRIPTION
Do not overload semantics of functions based on its parameters, especially if it's a variadic.

Fixes #71.